### PR TITLE
Harden supply-chain trust for image and releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 .Dockerfile
 .DS_Store
 node_modules/
+.git
+.github
+*.md
+LICENSE

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,37 +3,112 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - '.github/workflows/**'
+    tags: [ "v*" ]
+  pull_request:
   workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/schack/cloudflare-d1-backup
+
+permissions: {}
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Lint Dockerfile (hadolint)
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning
+
+      - name: Lint backup.sh (shellcheck)
+        run: shellcheck backup.sh
 
   build:
-  
+    needs: lint
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write        # gh release create on v* tags
+      packages: write        # push to ghcr
+      id-token: write        # keyless cosign signing + buildx provenance
+      security-events: write # upload Trivy SARIF
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6.0.2
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Extract Version
-      id: version
-      run: |
-        v=$(jq -r '.dependencies.wrangler' package.json | sed 's/^[\^~]//')
-        echo "version=$v" >> "$GITHUB_OUTPUT"
-     
-    - name: Login to ghcr.io
-      uses: docker/login-action@v4.2.0
-      with:
-        registry: ghcr.io
-        username: schack
-        password: ${{ secrets.PUSH_TOKEN }}
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-    - name: Build the Docker image
-      run: docker build -t ghcr.io/schack/cloudflare-d1-backup:${{ steps.version.outputs.version }} .
-    
-    - name: Push the Docker image to ghcr.io
-      run: |
-         docker push ghcr.io/schack/cloudflare-d1-backup:${{ steps.version.outputs.version }}
-         docker tag ghcr.io/schack/cloudflare-d1-backup:${{ steps.version.outputs.version }} ghcr.io/schack/cloudflare-d1-backup:latest
-         docker push ghcr.io/schack/cloudflare-d1-backup:latest
+      - name: Login to ghcr.io
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Extract wrangler version
+        id: version
+        run: |
+          v=$(jq -r '.dependencies.wrangler' package.json | sed 's/^[\^~]//')
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.version.outputs.version }},enable={{is_default_branch}}
+            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Scan image (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          # Report-only: never fail the build on findings (base-image CVEs are
+          # often out of our control). Results surface in the Security tab.
+          exit-code: '0'
+
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: '27 5 * * 1'   # Mondays 05:27 UTC (off-peak minute)
+  branch_protection_rule:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload SARIF to code scanning
+      id-token: write         # publish results to the Scorecard API (badge)
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-06-22
+
+First versioned release, focused on supply-chain trustworthiness.
+
+### Added
+- Keyless cosign signatures on every published image (Sigstore + GitHub OIDC).
+- SBOM and SLSA provenance attestations attached to the image (buildx).
+- Multi-architecture images: `linux/amd64` and `linux/arm64`.
+- Immutable `sha-<commit>` image tags for traceability (alongside `latest` and
+  the wrangler-version tag).
+- GitHub Releases cut from `v*` git tags.
+- CI lint gate: hadolint (Dockerfile) and shellcheck (`backup.sh`).
+- Trivy image vulnerability scanning (report-only; results in the Security tab).
+- OpenSSF Scorecard workflow and `SECURITY.md` disclosure policy.
+
+### Changed
+- The image is now pushed using the ephemeral `GITHUB_TOKEN` instead of a
+  long-lived personal access token.
+- Base image and all GitHub Actions are pinned by digest / commit SHA.
+- Workflow runs with least-privilege, per-job `permissions`.
+
+### Security
+- **Breaking:** the container now runs as the non-root `node` user (uid 1000).
+  The host directory mounted at `/tmp/backup` must be writable by uid 1000, e.g.
+  `chown 1000:1000 <host-backup-dir>` (or `chmod 0777`) before running.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # Stage 1: Build
-FROM node:24-alpine AS build
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
 # Stage 2: Production
-FROM node:24-alpine
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6
 WORKDIR /app
 COPY --from=build /app .
 COPY backup.sh backup.sh
+# Run unprivileged. The node image ships uid/gid 1000 (node); the backup only
+# writes to /tmp, so the mounted /tmp/backup volume must be writable by uid 1000.
+USER node
 CMD ["sh", "backup.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # cloudflare-d1-backup
+
+[![Docker Image CI](https://github.com/schack/cloudflare-d1-backup/actions/workflows/docker-image.yml/badge.svg)](https://github.com/schack/cloudflare-d1-backup/actions/workflows/docker-image.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/schack/cloudflare-d1-backup/badge)](https://scorecard.dev/viewer/?uri=github.com/schack/cloudflare-d1-backup)
+
 ### Simple backup tool for Cloudflare D1 databases.
 
 
@@ -13,6 +17,13 @@ docker run --rm \
   -e FILE_PREFIX="<filename prefix for backup files>" \
   -v <path to backup file storage>:/tmp/backup \
   ghcr.io/schack/cloudflare-d1-backup
+```
+
+The container runs as the non-root `node` user (uid 1000), so the host
+directory mounted at `/tmp/backup` must be writable by uid 1000:
+
+```
+chown 1000:1000 <path to backup file storage>
 ```
 
 ### Environment variables
@@ -41,3 +52,28 @@ Virtual table indexes are derived data — they regenerate automatically when
 you re-apply your schema migrations and re-import the row data, so excluding
 them from the backup is safe.
 
+### Verifying the image
+
+Every published image is multi-arch (`linux/amd64` + `linux/arm64`), signed with
+Sigstore cosign (keyless), and ships SBOM + SLSA provenance attestations.
+
+Verify the signature (https://docs.sigstore.dev/cosign/verifying/verify/):
+
+```
+cosign verify ghcr.io/schack/cloudflare-d1-backup:latest \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/schack/cloudflare-d1-backup/\.github/workflows/docker-image\.yml@.*'
+```
+
+Inspect the attached attestations and platforms:
+
+```
+docker buildx imagetools inspect ghcr.io/schack/cloudflare-d1-backup:latest
+cosign download sbom ghcr.io/schack/cloudflare-d1-backup:latest
+```
+
+For reproducible deployments, pin by digest rather than by tag.
+
+### Security
+
+See SECURITY.md for the vulnerability disclosure policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+This project ships a single rolling container image. Security fixes are applied
+to the latest release only; always run the most recent `:latest` (or a pinned
+digest of it). Older tags are not patched.
+
+## Reporting a vulnerability
+
+Please report security issues privately — do **not** open a public issue.
+
+- Preferred: GitHub private vulnerability reporting via the **Security** tab →
+  **Report a vulnerability** (https://github.com/schack/cloudflare-d1-backup/security/advisories/new).
+- Alternatively, email henrik.schack@storytel.com.
+
+Please include reproduction steps and affected version/digest. You can expect an
+acknowledgement within a few days. Once a fix is available, a new image is
+published and the advisory disclosed.
+
+## Handling of credentials
+
+This tool requires a Cloudflare API token (`CLOUDFLARE_API_TOKEN`). Scope it to
+**D1 read** only and pass it as an environment variable / secret at runtime — it
+is never written to the image or to backup files. The container runs as a
+non-root user (uid 1000).
+
+## Verifying releases
+
+Release images are signed with Sigstore cosign (keyless) and ship SBOM and SLSA
+provenance attestations. See the "Verifying the image" section of the README for
+the exact verification commands.

--- a/backup.sh
+++ b/backup.sh
@@ -2,13 +2,14 @@
 
 # Check all required environment vars are set.
 for var in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID DATABASE_NAME DATABASE_ID; do
-   if [ -z "$(eval echo \$$var)" ]; then
-    echo "Error: $var is not set."
+  eval "value=\${$var:-}"
+  if [ -z "$value" ]; then
+    echo "Error: $var is not set." >&2
     exit 1
   fi
 done
 
-# Use default filename prefix if not set. 
+# Use default filename prefix if not set.
 : "${FILE_PREFIX:=d1-database}"
 
 # Create configuration for wrangler.
@@ -29,5 +30,7 @@ for t in ${TABLES:-}; do
 done
 
 FILENAME="/tmp/backup/${FILE_PREFIX}-$(date +'%Y-%m-%d-%H-%M').sql"
-node_modules/wrangler/bin/wrangler.js -c /tmp/wrangler.toml d1 export --remote ${DATABASE_NAME} ${TABLE_FLAGS} --output $FILENAME
-gzip $FILENAME
+# TABLE_FLAGS must word-split into separate --table arguments; keep it unquoted.
+# shellcheck disable=SC2086
+node_modules/wrangler/bin/wrangler.js -c /tmp/wrangler.toml d1 export --remote "${DATABASE_NAME}" ${TABLE_FLAGS} --output "$FILENAME"
+gzip "$FILENAME"


### PR DESCRIPTION
## Why

`ghcr.io/schack/cloudflare-d1-backup` ingests a Cloudflare API token and produces backups people restore from, but today it's **unsigned, has no SBOM/provenance, is pushed with a long-lived PAT, builds from a mutable base tag, and has no lint/scan gate** — it would even fail this repo's own `cooled-image` cosign+multi-arch verification. This PR closes that gap.

## What changed

**Image**
- Pin base image by digest; run as **non-root** (`USER node`, uid 1000)
- **Multi-arch** build (amd64+arm64) with **SBOM + SLSA provenance** attestations
- **Keyless cosign** signing of the image digest

**Pipeline**
- Push with ephemeral **`GITHUB_TOKEN`** instead of a long-lived PAT
- Least-privilege per-job `permissions`; all actions **pinned by commit SHA**
- `lint` gate (hadolint + shellcheck) runs on PRs without pushing images
- **Trivy** scan (report-only) → SARIF in the Security tab
- Immutable `sha-<commit>` tags; **GitHub Releases** cut on `v*` tags

**Repo**
- Add `SECURITY.md`, `CHANGELOG.md`, **OpenSSF Scorecard** workflow
- Tighten `.dockerignore`; README badges + `cosign verify` instructions

## ⚠️ Breaking change
The container now runs as **uid 1000**, so the host directory mounted at `/tmp/backup` must be writable by uid 1000 (`chown 1000:1000 <dir>`). Documented in CHANGELOG and README. This is why it's tagged `1.0.0`.

## Verified locally
- hadolint: clean · shellcheck: clean · actionlint: clean
- single-arch build → `id` shows uid=1000(node), wrangler present
- `docker buildx build --platform linux/amd64,linux/arm64` builds both

## Note on merging
This is the **first PR under the new `main` ruleset** (requires the `lint` check). The `lint` job is introduced by this PR and runs on it, so the required check will report here and can be satisfied normally.

## Follow-ups (manual, repo settings)
- Delete the `PUSH_TOKEN` secret (no longer used)
- Enable **Private vulnerability reporting** (Settings → Security)
- After merge, cut the first release: `git tag v1.0.0 && git push origin v1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)