### PR TITLE
Auto-release per wrangler version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -100,7 +100,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-results.sarif
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main" ]
-    tags: [ "v*" ]
   pull_request:
   workflow_dispatch:
 
@@ -71,8 +70,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.version.outputs.version }},enable={{is_default_branch}}
             type=sha
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
         id: build
@@ -107,8 +104,18 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
+      # Auto-cut a GitHub Release per wrangler version: create v<version> only
+      # when that version has no release yet, so a wrangler bump releases while
+      # code-only changes just refresh the latest/sha tags.
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          tag="v${VERSION}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists; skipping."
+          else
+            gh release create "$tag" --target "$GITHUB_SHA" --generate-notes
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,6 @@ jobs:
           publish_results: true
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
 All notable changes to this project are documented here. The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
-adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Release versions track
+the bundled Cloudflare wrangler release (the image tag); each wrangler bump is
+auto-released as `v<wrangler-version>`. Changes to this tool's own code ship
+under the wrangler version current at the time and are noted here.
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-06-22
+## [4.94.0] - 2026-06-22
 
-First versioned release, focused on supply-chain trustworthiness.
+First versioned release, focused on supply-chain trustworthiness (ships with
+wrangler 4.94.0).
 
 ### Added
 - Keyless cosign signatures on every published image (Sigstore + GitHub OIDC).


### PR DESCRIPTION
## Why

Follow-up to #22. Instead of an independent semver (the `1.0.0` path) and manual `v*` tag pushes, releases now track the bundled **wrangler version** — fitting, since this tool is a thin wrapper around wrangler — and happen **automatically** with zero manual tagging.

## What changed

- **Auto-release on `main`:** each build creates a GitHub Release `v<wrangler-version>` *only if that version has no release yet*. So a wrangler bump (e.g. → `4.95.0`) cuts a release; code-only changes just refresh the `latest` + `sha-<commit>` image tags without a new release.
- Dropped the `tags: [v*]` trigger and the redundant `type=semver` image tags (the wrangler-version raw tag already provides `4.94.0`).
- `CHANGELOG.md` now tracks the wrangler version; first entry is **4.94.0** (was 1.0.0). The non-root breaking change is documented under it.

## Behavior summary

| Change on `main` | Image tags | GitHub Release |
|---|---|---|
| wrangler bump | `latest`, `sha-…`, `<new-version>` | new `v<new-version>` |
| code-only | `latest`, `sha-…`, `<same-version>` | none (version unchanged) |

## Verified
- actionlint: clean (exit 0)
- Release step uses only trusted inputs (`VERSION` from `package.json`, built-in `GITHUB_SHA`) — no injection surface.

## Note
First merge of this will auto-create release **v4.94.0** from the `main` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)