### PR TITLE
Serialize main builds and document rolling image tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,13 @@ on:
 env:
   IMAGE: ghcr.io/schack/cloudflare-d1-backup
 
+# Serialize main builds so that when several PRs are merged in quick succession
+# the newest commit's build finishes last and cleanly owns the rolling `latest`
+# and `<wrangler-version>` tags. PR builds (lint only) cancel superseded runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ under the wrangler version current at the time and are noted here.
 
 ## [Unreleased]
 
+### Changed
+- Serialize `main` builds via a workflow concurrency group so rapid successive
+  merges don't race for the rolling `latest` / `<wrangler-version>` tags.
+- Document the image tag model: `latest` and `<wrangler-version>` are rolling;
+  pin by digest or `sha-<commit>` for reproducible deployments.
+
 ## [4.94.0] - 2026-06-22
 
 First versioned release, focused on supply-chain trustworthiness (ships with

--- a/README.md
+++ b/README.md
@@ -72,7 +72,28 @@ docker buildx imagetools inspect ghcr.io/schack/cloudflare-d1-backup:latest
 cosign download sbom ghcr.io/schack/cloudflare-d1-backup:latest
 ```
 
-For reproducible deployments, pin by digest rather than by tag.
+### Image tags and pinning
+
+| Tag | Mutability | Use it for |
+|---|---|---|
+| `latest` | rolling | always the newest build |
+| `<wrangler-version>` (e.g. `4.94.0`) | rolling | the newest build bundling that wrangler version — it keeps receiving base-image and dependency security rebuilds within the same version line |
+| `sha-<commit>` | immutable | a specific build |
+
+Each push to `main` builds and publishes an image. The `<wrangler-version>` tag
+matches the bundled wrangler release and **moves forward** as non-wrangler
+changes (base image, dependency, or workflow updates) are merged, so it is not a
+fixed point. A GitHub Release `v<wrangler-version>` is cut once, marking when
+that version line started.
+
+**For reproducible deployments, pin by digest** (or by an immutable
+`sha-<commit>` tag), not by `latest` or `<wrangler-version>`:
+
+```
+docker run ... ghcr.io/schack/cloudflare-d1-backup@sha256:<digest>
+```
+
+Resolve the current digest with `docker buildx imagetools inspect`.
 
 ### Security
 


### PR DESCRIPTION
## Why

Follow-up to the auto-release-per-wrangler-version model (#23). Two issues surface when several PRs land close together without bumping wrangler:

1. **Race:** each merge builds an image, and both builds pushed concurrently could finish out of order — an older build could overwrite the rolling `latest` / `<wrangler-version>` tags with a stale image.
2. **Ambiguity:** the `<wrangler-version>` tag is *rolling* (moves forward as base-image/dep/workflow changes land within the same wrangler line), which wasn't documented — easy to mistake it for an immutable pin.

## What changed (option A — embrace the rolling model)

- **Concurrency group** on the workflow, keyed by ref:
  - `main` pushes **queue** (`cancel-in-progress: false`) → the newest commit's build finishes last and cleanly owns the rolling tags.
  - PR builds (lint only) **cancel** superseded runs to save CI minutes.
- **README "Image tags and pinning"** section: a table making explicit that `latest` and `<wrangler-version>` are rolling, `sha-<commit>`/digest are immutable, and that reproducible deploys should pin by digest.
- CHANGELOG note under Unreleased.

## Behavior after this

| Tag | Mutability |
|---|---|
| `latest` | rolling |
| `<wrangler-version>` | rolling (gets security rebuilds within the line) |
| `sha-<commit>` / digest | immutable — use for pinning |

The GitHub Release `v<wrangler-version>` remains a one-time marker for when that version line started; immutability is provided by the digest/sha tags.

## Verified
- actionlint: clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)