### PR TITLE
Retire CHANGELOG.md in favor of GitHub Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,10 @@
 # Changelog
 
-All notable changes to this project are documented here. The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Release versions track
-the bundled Cloudflare wrangler release (the image tag); each wrangler bump is
-auto-released as `v<wrangler-version>`. Changes to this tool's own code ship
-under the wrangler version current at the time and are noted here.
+This project's changelog lives on the **GitHub Releases** page, where a release
+is published automatically for each bundled wrangler version with notes
+generated from the merged pull requests:
 
-## [Unreleased]
+https://github.com/schack/cloudflare-d1-backup/releases
 
-### Changed
-- Serialize `main` builds via a workflow concurrency group so rapid successive
-  merges don't race for the rolling `latest` / `<wrangler-version>` tags.
-- Document the image tag model: `latest` and `<wrangler-version>` are rolling;
-  pin by digest or `sha-<commit>` for reproducible deployments.
-
-## [4.94.0] - 2026-06-22
-
-First versioned release, focused on supply-chain trustworthiness (ships with
-wrangler 4.94.0).
-
-### Added
-- Keyless cosign signatures on every published image (Sigstore + GitHub OIDC).
-- SBOM and SLSA provenance attestations attached to the image (buildx).
-- Multi-architecture images: `linux/amd64` and `linux/arm64`.
-- Immutable `sha-<commit>` image tags for traceability (alongside `latest` and
-  the wrangler-version tag).
-- GitHub Releases cut from `v*` git tags.
-- CI lint gate: hadolint (Dockerfile) and shellcheck (`backup.sh`).
-- Trivy image vulnerability scanning (report-only; results in the Security tab).
-- OpenSSF Scorecard workflow and `SECURITY.md` disclosure policy.
-
-### Changed
-- The image is now pushed using the ephemeral `GITHUB_TOKEN` instead of a
-  long-lived personal access token.
-- Base image and all GitHub Actions are pinned by digest / commit SHA.
-- Workflow runs with least-privilege, per-job `permissions`.
-
-### Security
-- **Breaking:** the container now runs as the non-root `node` user (uid 1000).
-  The host directory mounted at `/tmp/backup` must be writable by uid 1000, e.g.
-  `chown 1000:1000 <host-backup-dir>` (or `chmod 0777`) before running.
+Image tags track the wrangler version; see the "Image tags and pinning" section
+of the README for what's rolling versus immutable.


### PR DESCRIPTION
## Why

The version tracks the bundled wrangler release and a GitHub Release is auto-published per version with `--generate-notes`. A hand-maintained `CHANGELOG.md` just drifts against that: after the 4.96.0 bump it had no `4.96.0` entry and still listed PR #24's items under "Unreleased".

## What changed

Replace `CHANGELOG.md` contents with a short pointer to the GitHub Releases page (the auto-generated source of truth) and a note that image tags track the wrangler version. No other files reference the changelog, so nothing else needed updating.

## Follow-up (outside this PR)

Backfilling the `v4.94.0` release notes with the curated hardening + breaking-change summary so that history lives on the Releases page too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)