### PR TITLE
Add .npmrc pinning public registry to fix Dependabot npm job

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+; All dependencies come from the public npm registry. This is explicit so
+; Dependabot does not infer a private GitHub Packages registry (npm.pkg.github.com)
+; and abort with private_registry_config_not_found. Not used by the image build
+; (the Dockerfile does not COPY this file); npm's default registry is npmjs anyway.
+registry=https://registry.npmjs.org


### PR DESCRIPTION
## Problem

The weekly **npm version-update** Dependabot job started failing (reproducibly — confirmed across two runs) in the file-fetching phase:

```
private_registry_config_not_found  source: npm.pkg.github.com
```

Dependabot decided it needs the GitHub Packages npm registry and found no config for it.

## Diagnosis

- **Nothing in the repo references `npm.pkg.github.com`** — no `.npmrc`, no scoped private deps, every `package-lock.json` entry resolves to `registry.npmjs.org`.
- The **identical config worked on 2026-06-22** (PR #25). Dependabot alerts/security updates are disabled, so this is the plain version-update job.
- It aborts at manifest parsing, before checking for updates.

That points to a Dependabot-side change that now mis-infers a private GitHub Packages registry.

## Fix

Add a committed `.npmrc` that pins the default registry to public npm — one of the two remedies the error message itself names. This tells Dependabot all packages come from npmjs, so it stops inferring `npm.pkg.github.com`.

- **No effect on the image build:** the Dockerfile does not `COPY .npmrc`, and npmjs is npm's default anyway. This file only influences Dependabot.

## Verification

After merge to `main`, re-trigger Dependabot ("Check for updates") and confirm the npm job completes without `private_registry_config_not_found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)