### PR TITLE
Skip base-image npm CLI in Trivy scan (not runtime-reachable)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -102,6 +102,8 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: HIGH,CRITICAL
+          # Skips the base image's bundled npm CLI (not runtime-reachable). See trivy.yaml.
+          trivy-config: trivy.yaml
           # Report-only: never fail the build on findings (base-image CVEs are
           # often out of our control). Results surface in the Security tab.
           exit-code: '0'

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,19 @@
+# Trivy configuration for the image scan in .github/workflows/docker-image.yml.
+#
+# We skip the npm CLI that ships baked into the node:24-alpine base image. The
+# container runs `sh backup.sh` -> wrangler -> Cloudflare REST API and never
+# invokes npm at runtime, so CVEs in npm's bundled dependencies (sigstore, tar,
+# undici, ip-address, brace-expansion, ...) are not reachable. They also can't
+# be fixed from this repo: they track whatever npm the base image bundles, so
+# they'd sit "open" forever and bury genuinely actionable findings.
+#
+# Scoped by PATH (not by CVE id) on purpose: new npm-CLI CVEs land regularly,
+# and an id list would need constant hand-maintenance. The base image itself
+# still moves forward on the 21-day Dependabot cooldown (.github/dependabot.yml).
+#
+# NOTE: this only skips npm's *own* bundled tree under /usr/local. The app's
+# real dependencies under /app/node_modules (wrangler + undici/ws/esbuild) are
+# still scanned, so a genuinely reachable CVE will still surface.
+scan:
+  skip-dirs:
+    - usr/local/lib/node_modules/npm


### PR DESCRIPTION
## What

Adds `trivy.yaml` with `scan.skip-dirs` for `usr/local/lib/node_modules/npm` and wires it into the image scan step (`trivy-config: trivy.yaml`).

## Why

Every open Trivy alert under `usr/local/lib/node_modules/npm/**` is a CVE in the **npm CLI that ships baked into the `node:24-alpine` base image** (sigstore, tar, undici 6.25, ip-address, brace-expansion, ...). The container runs `sh backup.sh` → wrangler → Cloudflare REST API and **never invokes npm at runtime**, so these are not reachable. They also can't be fixed from this repo — they track whatever npm the base image bundles — so they sit "open" indefinitely and bury genuinely actionable findings.

Scoped by **path, not CVE id**, so new npm-CLI CVEs are covered automatically without hand-maintaining an ignore list.

## What this does *not* touch

- `/app/node_modules` (wrangler + undici/ws/esbuild) stays fully scanned — a genuinely reachable CVE still surfaces.
- The base image still advances on the 21-day Dependabot cooldown (`.github/dependabot.yml`); no supply-chain freshness is traded away.

## Verification

Confirmed locally against a mock tree: Trivy logs `Skipping path path="usr/local/lib/node_modules/npm"` while a control file under `app/node_modules/undici` is **not** skipped. Existing npm-CLI alerts will auto-close once a `main` build uploads SARIF without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)