### PR TITLE
Ignore Node major bumps via update-types (Dependabot -alpine tag fix)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,14 @@ updates:
     cooldown:
       default-days: 21
     ignore:
-      # Node LTS only: skip odd majors (never LTS) and even majors
-      # that are still "Current". Update this list each October when
-      # a new even major goes Active LTS (next: Node 26 in Oct 2026).
+      # Node LTS only: never auto-bump the major. Dependabot still offers
+      # 24.x minor/patch (-alpine) updates; bump the major by hand each
+      # October when the next even major goes Active LTS (Node 26, Oct 2026).
+      # NOTE: a `versions: ["25.x", ...]` list does NOT work here - the
+      # `-alpine` tag suffix stops the .x semver wildcard from matching, so
+      # Dependabot opened a 25-alpine PR anyway. update-types is reliable.
       - dependency-name: "node"
-        versions: ["23.x", "25.x", "26.x", "27.x"]
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What

Replace the ineffective `ignore.versions` list for the `node` Docker image with an `update-types` major-version ignore.

```yaml
- dependency-name: "node"
  update-types: ["version-update:semver-major"]
```

## Why

The Dockerfile pins `node:24-alpine` (Active LTS). The existing ignore rule used `versions: ["23.x", "25.x", "26.x", "27.x"]`, but the `.x` semver wildcard does **not** match suffixed Docker tags like `25-alpine` - the `-alpine` suffix makes the tag non-semver. So the ignore silently did nothing and Dependabot opened a `24-alpine` → `25-alpine` PR (#36, now closed). Node 25 is odd-numbered and never becomes LTS.

`update-types: version-update:semver-major` reliably blocks major bumps regardless of tag suffix, while still allowing `24.x` minor/patch `-alpine` updates. It also removes the annual chore of hand-editing the version list each October.

Next LTS (Node 26, ~Oct 2026) will be bumped by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)